### PR TITLE
Disable default recipe functionality, break into other recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@
 
 ## Usage
 
+By design, the `default` recipe does nothing. There are two convenience recipes included:
+* `cop_magento::full-install`: Configures environment and installs Magento
+* `cop_magento::pre-deploy`: Configures the environment for a pre-generated artifact deployment
+
 Here's an example `web` role that will install Magento
 
 ```
@@ -55,7 +59,27 @@ override_attributes(
 )
 
 run_list(
-    'recipe[cop_magento::default]'
+    'recipe[cop_magento::full-install]'
+)
+```
+
+Additionally, a recipe is included that will prepare the environment for deploying a generated artifact.
+This recipe does not actually install Magento, but creates the directory structure and all dependencies.
+A CI tool such as CircleCI can then be used to generate a deployable artifact which can be overlayed on
+this environment.
+
+```
+name 'web'
+description 'prep environment for Magento artifact deploy'
+
+override_attributes(
+    'magento': {
+        'domain': 'example.net',
+    }
+)
+
+run_list(
+    'recipe[cop_magento::pre-deploy]'
 )
 ```
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.0.1'
+version             '0.1.0'
 source_url          'https://github.com/copious-cookbooks/magento'
 issues_url          'https://github.com/copious-cookbooks/magento/issues'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,14 +3,4 @@
 # Recipe:: default
 #
 
-include_recipe 'cop_magento::data-bag'
-include_recipe 'cop_magento::users'
-include_recipe 'cop_magento::cli-tools'
-include_recipe 'cop_magento::dir-structure'
-if node.chef_environment == "development"
-    include_recipe 'cop_magento::dir-structure-vagrant'
-end
-include_recipe 'cop_magento::permissions'
-include_recipe 'cop_magento::robots'
-include_recipe 'cop_magento::composer-prep'
-include_recipe 'cop_magento::magento-install'
+# NOTE: Please see README for correct usage of this cookboook

--- a/recipes/full-install.rb
+++ b/recipes/full-install.rb
@@ -1,0 +1,16 @@
+#
+# Cookbook Name:: magento
+# Recipe:: default
+#
+
+include_recipe 'cop_magento::data-bag'
+include_recipe 'cop_magento::users'
+include_recipe 'cop_magento::cli-tools'
+include_recipe 'cop_magento::dir-structure'
+if node.chef_environment == "development"
+    include_recipe 'cop_magento::dir-structure-vagrant'
+end
+include_recipe 'cop_magento::permissions'
+include_recipe 'cop_magento::robots'
+include_recipe 'cop_magento::composer-prep'
+include_recipe 'cop_magento::magento-install'

--- a/recipes/full-install.rb
+++ b/recipes/full-install.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: magento
-# Recipe:: default
+# Recipe:: full-install
 #
 
 include_recipe 'cop_magento::data-bag'

--- a/recipes/pre-deploy.rb
+++ b/recipes/pre-deploy.rb
@@ -1,0 +1,12 @@
+#
+# Cookbook Name:: magento
+# Recipe:: default
+#
+
+include_recipe 'cop_magento::data-bag'
+include_recipe 'cop_magento::users'
+include_recipe 'cop_magento::cli-tools'
+include_recipe 'cop_magento::dir-structure'
+include_recipe 'cop_magento::permissions'
+include_recipe 'cop_magento::robots'
+include_recipe 'cop_magento::composer-prep'

--- a/recipes/pre-deploy.rb
+++ b/recipes/pre-deploy.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: magento
-# Recipe:: default
+# Recipe:: pre-deploy
 #
 
 include_recipe 'cop_magento::data-bag'


### PR DESCRIPTION
This pull request removes functionality from the default recipe. Instead, two new recipes can be used, one which does a complete install of Magento, and one which prepares the environment for a deployable artifact, preferably generated from a CI system. Additionally, the README is updated to reflect this new refactoring.

New recipes:
`cop_magento::full-install`
`cop_magento::pre-deploy`