### PR TITLE
Refactor cache_types attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -102,21 +102,21 @@ default['magento']['x_frame_options'] = 'SAMEORIGIN'
 
 default['magento']['mage_mode'] = 'production'
 
-default['magento']['cache_types'] = %w(
-    config
-    layout
-    block_html
-    collections
-    reflection
-    db_ddl
-    eav
-    customer_notification
-    full_page
-    config_integration
-    config_integration_api
-    translate
-    config_webservice
-)
+default['magento']['cache_types'] = {
+    "config" => 1,
+    "layout" => 1,
+    "block_html" => 1,
+    "collections" => 1,
+    "reflection" => 1,
+    "db_ddl" => 1,
+    "eav" => 1,
+    "customer_notification" => 1,
+    "full_page" => 1,
+    "config_integration" => 1,
+    "config_integration_api" => 1,
+    "translate" => 1,
+    "config_webservice" => 1
+}
 
 default['magento']['composer']['merge']['version']     = 'v1.3.1'
 default['magento']['composer']['merge']['recurse']     = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -102,20 +102,23 @@ default['magento']['x_frame_options'] = 'SAMEORIGIN'
 
 default['magento']['mage_mode'] = 'production'
 
-default['magento']['cache_types']['config']                 = 1
-default['magento']['cache_types']['layout']                 = 1
-default['magento']['cache_types']['block_html']             = 1
-default['magento']['cache_types']['collections']            = 1
-default['magento']['cache_types']['reflection']             = 1
-default['magento']['cache_types']['db_ddl']                 = 1
-default['magento']['cache_types']['eav']                    = 1
-default['magento']['cache_types']['customer_notification']  = 1
-default['magento']['cache_types']['full_page']              = 1
-default['magento']['cache_types']['config_integration']     = 1
-default['magento']['cache_types']['config_integration_api'] = 1
-default['magento']['cache_types']['translate']              = 1
-default['magento']['cache_types']['config_webservice']      = 1
+default['magento']['default_cache_types'] = %w(
+    config
+    layout
+    block_html
+    collections
+    reflection
+    db_ddl
+    eav
+    customer_notification
+    full_page
+    config_integration
+    config_integration_api
+    translate
+    config_webservice
+)
 
+default['magento']['additional_cache_types'] = %w()
 
 default['magento']['composer']['merge']['version']     = 'v1.3.1'
 default['magento']['composer']['merge']['recurse']     = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -102,7 +102,7 @@ default['magento']['x_frame_options'] = 'SAMEORIGIN'
 
 default['magento']['mage_mode'] = 'production'
 
-default['magento']['default_cache_types'] = %w(
+default['magento']['cache_types'] = %w(
     config
     layout
     block_html
@@ -117,8 +117,6 @@ default['magento']['default_cache_types'] = %w(
     translate
     config_webservice
 )
-
-default['magento']['additional_cache_types'] = %w()
 
 default['magento']['composer']['merge']['version']     = 'v1.3.1'
 default['magento']['composer']['merge']['recurse']     = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.4.1'
+version             '0.5.0'
 source_url          'https://github.com/copious-cookbooks/magento'
 issues_url          'https://github.com/copious-cookbooks/magento/issues'
 

--- a/templates/magento/env.php.erb
+++ b/templates/magento/env.php.erb
@@ -112,11 +112,8 @@ return array (
   'MAGE_MODE' => '<%= node['magento']['mage_mode'] %>',
   'cache_types' =>
   array (
-    <% node['magento']['default_cache_types'].each do |cache_type| %>
+    <% node['magento']['cache_types'].each do |cache_type| %>
     '<%= cache_type %>' => 1,
     <% end %>
-    <% node['magento']['additional_cache_types'].each do |cache_type| %>
-    '<%= cache_type %>' => 1,
-    <% end %>
-  ),
+     ),
 );

--- a/templates/magento/env.php.erb
+++ b/templates/magento/env.php.erb
@@ -112,17 +112,11 @@ return array (
   'MAGE_MODE' => '<%= node['magento']['mage_mode'] %>',
   'cache_types' =>
   array (
-    'config' => <%= node['magento']['cache_types']['config'] %>,
-    'layout' => <%= node['magento']['cache_types']['layout'] %>,
-    'block_html' => <%= node['magento']['cache_types']['block_html'] %>,
-    'collections' => <%= node['magento']['cache_types']['collections'] %>,
-    'reflection' => <%= node['magento']['cache_types']['reflection'] %>,
-    'db_ddl' => <%= node['magento']['cache_types']['db_ddl'] %>,
-    'eav' => <%= node['magento']['cache_types']['eav'] %>,
-    'config_integration' => <%= node['magento']['cache_types']['config_integration'] %>,
-    'config_integration_api' => <%= node['magento']['cache_types']['config_integration_api'] %>,
-    'full_page' => <%= node['magento']['cache_types']['full_page'] %>,
-    'translate' => <%= node['magento']['cache_types']['translate'] %>,
-    'config_webservice' => <%= node['magento']['cache_types']['config_webservice'] %>,
+    <% node['magento']['default_cache_types'].each do |cache_type| %>
+    '<%= cache_type %>' => 1,
+    <% end %>
+    <% node['magento']['additional_cache_types'].each do |cache_type| %>
+    '<%= cache_type %>' => 1,
+    <% end %>
   ),
 );

--- a/templates/magento/env.php.erb
+++ b/templates/magento/env.php.erb
@@ -112,8 +112,8 @@ return array (
   'MAGE_MODE' => '<%= node['magento']['mage_mode'] %>',
   'cache_types' =>
   array (
-    <% node['magento']['cache_types'].each do |cache_type| %>
-    '<%= cache_type %>' => 1,
+    <% node['magento']['cache_types'].each do |cache_type, value| %>
+   '<%= cache_type %>' => <%= value %>,
     <% end %>
      ),
 );


### PR DESCRIPTION
Refactors multiple `cache_types` attributes into a hash which can be updated and overridden. The `env.php` template has been updated to loop through this hash instead of applying hard coded attributes. This allows for projects to enable and disable cache types without requiring a rewrite of the `env.php` template.