### PR TITLE
Add attribute for 'release path'

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,6 +9,7 @@ default['magento']['additional_domains'] = {}
 # Docroot
 default['magento']['docroot']           = "/var/www/#{node['magento']['domain']}"
 default['magento']['installation_path'] = "#{node['magento']['docroot']}/releases/primary/magento"
+default['magento']['release']           = "#{node['magento']['docroot']}/releases/primary"
 
 # Users and groups
 default['magento']['cli_user']['name']  = 'mage-cli'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.6.0'
+version             '0.7.0'
 source_url          'https://github.com/copious-cookbooks/magento'
 issues_url          'https://github.com/copious-cookbooks/magento/issues'
 

--- a/recipes/magento-install.rb
+++ b/recipes/magento-install.rb
@@ -5,6 +5,7 @@
 
 docroot                 = node['magento']['docroot']
 magento_path            = node['magento']['installation_path']
+release_path            = node['magento']['release']
 magento_bin             = "#{magento_path}/bin/magento"
 magento_composer_home   = "#{magento_path}/var/composer_home"
 
@@ -88,7 +89,7 @@ end
 
 link "Symlink docroot" do
     target_file "#{docroot}/current"
-    to          magento_path
+    to          release_path
     owner       cli_user
     group       www_group
    action       :nothing


### PR DESCRIPTION
Breaks up attribute that referred to the installation path of Magento into two unique attributes. Originally, the installation path was reused when symlinking `/var/www/<domain>/current` which causes the symlink to point directly to `/var/www/<domain>/releases/<release>/magento` and bypasses additional folders present in the <release> directory. As we are using a `src` directory in many of our projects, this allows independently setting the symlink point from the installation point, therefore allowing for the symlink to be set up a directory at `/var/www/<domain>/releases/<release>/`.