### PR TITLE
Only create `$DOCROOT/releases/primary/` directories if `full-install` recipe called

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,8 +7,8 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.19.36
-  # NOTE: 13.0.113 breaks 'cop_base', pinned to last stable release
+  require_chef_omnibus: 13.1.31
+  # Last tested version
   environments_path: "test/integration/environments"
   client_rb:
     environment: development

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.7.5'
+version             '0.7.6'
 source_url          'https://github.com/copious-cookbooks/magento'
 issues_url          'https://github.com/copious-cookbooks/magento/issues'
 

--- a/recipes/dir-structure.rb
+++ b/recipes/dir-structure.rb
@@ -18,13 +18,6 @@ dir_permissions    = node['magento']['directory']['permissions']
 
 dirs = %w(
     releases
-    releases/primary
-    releases/primary/magento
-    releases/primary/magento/app
-    releases/primary/magento/app/etc
-    releases/primary/magento/var
-    releases/primary/magento/var/session
-    releases/primary/magento/vendor
     shared
     shared/app
     shared/app/etc
@@ -34,6 +27,19 @@ dirs = %w(
     shared/pub/media
     shared/var
 )
+
+# If the `full-install` recipe is in the run_list, add to the directory structure
+if node.recipe?('cop_magento::full-install')
+    dirs += %w(
+        releases/primary
+        releases/primary/magento
+        releases/primary/magento/app
+        releases/primary/magento/app/etc
+        releases/primary/magento/var
+        releases/primary/magento/var/session
+        releases/primary/magento/vendor
+    )
+end
 
 vagrant_dirs = %w(
     /vagrant


### PR DESCRIPTION
Prevents the `/var/www/<domain>/releases/primary/...` directory structure from being created unless the `full-install` recipe is called. This eliminates cruft in the releases folder on staging/production environments which typically do not see an initial installation.

Additionally brings Kitchen test suite in line with dependency cookbooks by bumping Chef to v13.