### PR TITLE
Link robots.txt out of shared directory

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,7 +36,13 @@ suites:
       - recipe[cop_magento::full-install]
     attributes:
       robots:
-        allow: false
+        allow: true
+        user_agents:
+          test-agent:
+            - 'path/to/file'
+            - 'var/www/*'
+        sitemaps:
+          example.com: 'http://www.example.com/sitemap.xml'
       magento:
         additional_domains:
           - "example.net"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.7.6'
+version             '0.7.7'
 source_url          'https://github.com/copious-cookbooks/magento'
 issues_url          'https://github.com/copious-cookbooks/magento/issues'
 

--- a/recipes/magento-install.rb
+++ b/recipes/magento-install.rb
@@ -142,6 +142,13 @@ link "#{magento_path}/app/etc/env.php" do
     group www_group
 end
 
+# Link `robots.txt`
+link "#{magento_path}/pub/robots.txt" do
+    to    "#{docroot}/shared/pub/robots.txt"
+    owner cli_user
+    group www_group
+end
+
 execute 'Set Magento deploy mode' do
     command "#{magento_bin} -#{verbosity} deploy:mode:set #{node['magento']['mage_mode']} --skip-compilation"
     cwd     magento_path

--- a/templates/robots/robots.txt.erb
+++ b/templates/robots/robots.txt.erb
@@ -9,8 +9,10 @@ User-agent: <%= user_agent %>
 Disallow: <%= dir %>
         <% end -%>
     <% end -%>
+    <% if node['robots']['sitemaps'] -%>
+        <% node['robots']['sitemaps'].each do |name, sitemap| -%>
 
-    <% node['robots']['sitemaps'].each do |name, sitemap| -%>
 Sitemap: <%= sitemap %>
+        <% end -%>
     <% end -%>
 <% end -%>

--- a/templates/robots/robots.txt.erb
+++ b/templates/robots/robots.txt.erb
@@ -9,9 +9,9 @@ User-agent: <%= user_agent %>
 Disallow: <%= dir %>
         <% end -%>
     <% end -%>
+
     <% if node['robots']['sitemaps'] -%>
         <% node['robots']['sitemaps'].each do |name, sitemap| -%>
-
 Sitemap: <%= sitemap %>
         <% end -%>
     <% end -%>

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -24,6 +24,13 @@ describe 'magento::robots' do
         it { should be_grouped_into 'www-data' }
         it { should be_mode 644 }
     end
+
+    describe file('/var/www/example.com/current/magento/pub/robots.txt') do
+        it { should exist }
+        it { should be_symlink }
+        it { should be_owned_by 'mage-cli' }
+        it { should be_grouped_into 'www-data' }
+    end
 end
 
 describe 'magento::composer-prep' do


### PR DESCRIPTION
During the installation process, `magento-install.rb` will symlink `/var/www/<domain>/shared/pub/robots.txt` to `/var/www/<domain>/current/magento/pub/robots.txt`