### PR TITLE
Only create installation composer.json when installing Magento

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.7.7'
+version             '0.7.8'
 source_url          'https://github.com/copious-cookbooks/magento'
 issues_url          'https://github.com/copious-cookbooks/magento/issues'
 

--- a/recipes/composer-prep.rb
+++ b/recipes/composer-prep.rb
@@ -54,14 +54,17 @@ template 'Creating shared composer.json' do
 end
 
 # Generate Composer composer.json in installation directory
-template 'Creating installation composer.json' do
-    path    "#{magento_path}/composer.json"
-    source  'composer/composer.json.erb'
-    owner   cli_user
-    group   www_group
-    mode    0644
-    action  :create
-    backup  false
+# Only takes effect if 'full-install' recipe is used
+if node.recipe?('cop_magento::full-install')
+    template 'Creating installation composer.json' do
+        path    "#{magento_path}/composer.json"
+        source  'composer/composer.json.erb'
+        owner   cli_user
+        group   www_group
+        mode    0644
+        action  :create
+        backup  false
+    end
 end
 
 # Generate env.php


### PR DESCRIPTION
Puts a check in place to create `node['magento']['installation_path']/composer.json` only if the `full-install` recipe is called. Prevents a fail condition when `node['magento']['installation_path']` directory does not exist. This can happen when a system has never had `full-install` recipe ran, only `pre-deploy`.