### PR TITLE
Hotfix NGINX conf file permissions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.7.8'
+version             '0.7.9'
 source_url          'https://github.com/copious-cookbooks/magento'
 issues_url          'https://github.com/copious-cookbooks/magento/issues'
 

--- a/recipes/nginx-vhost.rb
+++ b/recipes/nginx-vhost.rb
@@ -12,7 +12,7 @@ template 'magento config for nginx' do
     source 'nginx/magento.erb'
     owner  'root'
     group  'root'
-    mode   0755
+    mode   0644
     action :create
     variables(
         fpm_location: "unix:#{fpm_location}",
@@ -28,7 +28,7 @@ template 'magento variables for nginx' do
     source 'nginx/magento.conf.erb'
     owner  'root'
     group  'root'
-    mode   0755
+    mode   0644
     action :create
     notifies :reload, 'service[nginx]', :immediately
 end


### PR DESCRIPTION
Drops permissions from `755` to `644`, bumps metadata.