### PR TITLE
Create Redis 'page_cache' config only if Varnish not enabled

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.8.0'
+version             '0.8.1'
 source_url          'https://github.com/copious-cookbooks/magento'
 issues_url          'https://github.com/copious-cookbooks/magento/issues'
 

--- a/templates/magento/env.php.erb
+++ b/templates/magento/env.php.erb
@@ -73,6 +73,7 @@ return array (
           'compression_lib' => '<%= node['magento']['cache']['redis']['default']['compression_lib'] %>',
         ),
       ),
+<% unless node['magento']['varnish']['enabled'] -%>
       'page_cache' =>
       array (
         'backend' => '<%= node['magento']['cache']['redis']['page_cache']['backend'] %>',
@@ -89,6 +90,7 @@ return array (
           'compress_data' => '<%= node['magento']['cache']['redis']['page_cache']['compress_data'] %>',
         ),
       ),
+<% end -%>
     ),
   ),
 <% end -%>


### PR DESCRIPTION
Prevents creation of the Redis `page_cache` array block if Varnish is enabled.