### PR TITLE
Sitemaps shared directory

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.9.0'
+version             '0.9.1'
 source_url          'https://github.com/copious-cookbooks/magento'
 issues_url          'https://github.com/copious-cookbooks/magento/issues'
 

--- a/recipes/dir-structure.rb
+++ b/recipes/dir-structure.rb
@@ -23,8 +23,9 @@ dirs = %w(
     shared/app/etc
     shared/composer
     shared/pub
-    shared/pub/static
     shared/pub/media
+    shared/pub/sitemaps
+    shared/pub/static
     shared/var
 )
 


### PR DESCRIPTION
Creates directory `shared/pub/sitemaps/` as a bucket for creation of arbitrary sitemaps via Magento.