### PR TITLE
Use full Composer binary path

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.9.1'
+version             '0.9.2'
 source_url          'https://github.com/copious-cookbooks/magento'
 issues_url          'https://github.com/copious-cookbooks/magento/issues'
 

--- a/recipes/magento-install.rb
+++ b/recipes/magento-install.rb
@@ -16,6 +16,7 @@ www_user                = node['magento']['www_user']['name']
 www_group               = node['magento']['www_user']['group']
 
 composer_home           = "/home/#{cli_user}/.composer"
+composer_binary_path    = node['composer']['binary']['path']
 
 verbosity               = node['magento']['installation']['verbosity']
 
@@ -57,7 +58,7 @@ end
 
 # Run composer install
 execute 'Composer installing' do
-    command     "composer install -#{verbosity} #{composer_install_flags}"
+    command     "#{composer_binary_path} -#{verbosity} #{composer_install_flags}"
     cwd         magento_path
     user        cli_user
     group       www_group

--- a/recipes/magento-install.rb
+++ b/recipes/magento-install.rb
@@ -58,7 +58,7 @@ end
 
 # Run composer install
 execute 'Composer installing' do
-    command     "#{composer_binary_path} -#{verbosity} #{composer_install_flags}"
+    command     "#{composer_binary_path} install -#{verbosity} #{composer_install_flags}"
     cwd         magento_path
     user        cli_user
     group       www_group


### PR DESCRIPTION
Uses full binary path instead of assuming `composer` exists in the executing users PATH.